### PR TITLE
Fixed country option "Taiwan"

### DIFF
--- a/lab2/interaction/placenames/index.html
+++ b/lab2/interaction/placenames/index.html
@@ -232,7 +232,7 @@
 				<option value="SE">Sweden</option>
 				<option value="CH">Switzerland</option>
 				<option value="SY">Syrian Arab Republic</option>
-				<option value="TW">Taiwan, Province of China</option>
+				<option value="TW">Taiwan</option>
 				<option value="TJ">Tajikistan</option>
 				<option value="TZ">Tanzania, United Republic of</option>
 				<option value="TH">Thailand</option>


### PR DESCRIPTION
Still wanted to give my country a correct name, although I'm so used to this.
Updated `<option value="TW">Taiwan, Province of China</option>` to `<option value="TW">Taiwan</option>`.
